### PR TITLE
Add support for custom Prometheus metrics and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,57 +53,57 @@ Metric access is controlled by three settings that can be configured using the [
   * `true` or `false`. If true, you must authenticate with HarperDB in order to access the metrics endpoint `/prometheus_exporter/metrics`
 2. `authorizedUsers`
    * Array of Username (HarperDB users) strings. Only used if `forceAuthorization` is `true`. If empty, the user used to authenticate must be a `super_user`. If there are any strings in the array, those users will be authorized to access as well as any super users.
-     3. `customMetrics`
-        * Object array of values that define converting Harper custom metric(s) to Prometheus metric(s). The definition is as follows:
-          * `metricAttribute` (required): The Harper metric name that needs to be processed as a custom Prometheus metric.
-          * `help` (required): The help text to be associated with the Prometheus metric.
-          * `labels` (required): Object array of label definitions for the Prometheus metric. The definition for labels:
-            * `label` (required): Name of the Prometheus label.
-            * `metricAttribute` (required): Name of the Harper label that maps to the Prometheus label.
-            * `delimiter` (optional): If the label value is a concatenated string, this defines the delimiter with which to split the data.
-            * `index` (optional / required with delimiter): This is used in conjunction with the delimiter attribute.  This creates the mapping from the split label value, based on delimiter, to the Prometheus label value.  `index` can also be used independently of delimiter if the Harper label value is an array.
+3. `customMetrics`
+   * Object array of values that define converting Harper custom metric(s) to Prometheus metric(s). The definition is as follows:
+     * `metricAttribute` (required): The Harper metric name that needs to be processed as a custom Prometheus metric.
+     * `help` (required): The help text to be associated with the Prometheus metric.
+     * `labels` (required): Object array of label definitions for the Prometheus metric. The definition for labels:
+       * `label` (required): Name of the Prometheus label.
+       * `metricAttribute` (required): Name of the Harper label that maps to the Prometheus label.
+       * `delimiter` (optional): If the label value is a concatenated string, this defines the delimiter with which to split the data.
+       * `index` (optional / required with delimiter): This is used in conjunction with the delimiter attribute.  This creates the mapping from the split label value, based on delimiter, to the Prometheus label value.  `index` can also be used independently of delimiter if the Harper label value is an array.
     
-          Example `customMetrics` value:      
-          ```json
-          {
-             "name": "customMetrics",
-              "value": [
+     Example `customMetrics` value:      
+     ```json
+     {
+        "name": "customMetrics",
+         "value": [
+        {
+           "name": "myCoolMetric",
+           "metricAttribute": "metric",
+           "help": "this is the coolest metric",
+           "labels": [
              {
-                "name": "myCoolMetric",
-                "metricAttribute": "metric",
-                "help": "this is the coolest metric",
-                "labels": [
-                  {
-                     "label": "coolLabel",
-                     "metricAttribute": "path"
-                     "delimiter": "::"
-                     "index": 0
-                  },
-                  {
-                     "label": "coolerLabel",
-                     "metricAttribute": "path"
-                     "delimiter": "::"
-                     "index": 1
-                  },
-                  {
-                     "label": "coolestLabel",
-                     "metricAttribute": "path"
-                     "delimiter": "::"
-                     "index": 2
-                  },
-                  {
-                     "label": "httpMethod",
-                     "metricAttribute": "method"
-                  },
-                  {
-                     "label": "statusCode",
-                     "metricAttribute": "type"
-                  }
-                ]
-            }
-          ]
-     }
-        ```
+                "label": "coolLabel",
+                "metricAttribute": "path"
+                "delimiter": "::"
+                "index": 0
+             },
+             {
+                "label": "coolerLabel",
+                "metricAttribute": "path"
+                "delimiter": "::"
+                "index": 1
+             },
+             {
+                "label": "coolestLabel",
+                "metricAttribute": "path"
+                "delimiter": "::"
+                "index": 2
+             },
+             {
+                "label": "httpMethod",
+                "metricAttribute": "method"
+             },
+             {
+                "label": "statusCode",
+                "metricAttribute": "type"
+             }
+           ]
+       }
+     ]
+   }
+      ```
 
 
 ### Example REST commands

--- a/README.md
+++ b/README.md
@@ -48,11 +48,63 @@ scrape_configs:
 We define a custom `metrics_path` to tell Prometheus where to access the HarperDB Exporter path.  You can also see we added a label for our target, we recommend doing similar for your configuration to allow for filtering between instance metrics.
 
 ## Exporter Settings
-Metric access is controlled by two settings that can be configured using the [REST](https://docs.harperdb.io/docs/developers/rest) endpoint for `prometheus_exporter/PrometheusExporterSettings`. The user used to authenticate these REST requests must have write access to the table `PrometheusExporterSettings`:
+Metric access is controlled by three settings that can be configured using the [REST](https://docs.harperdb.io/docs/developers/rest) endpoint for `prometheus_exporter/PrometheusExporterSettings`. The user used to authenticate these REST requests must have write access to the table `PrometheusExporterSettings`:
 1. `forceAuthorization`
   * `true` or `false`. If true, you must authenticate with HarperDB in order to access the metrics endpoint `/prometheus_exporter/metrics`
 2. `authorizedUsers`
-  * Array of Username (HarperDB users) strings. Only used if `forceAuthorization` is `true`. If empty, the user used to authenticate must be a `super_user`. If there are any strings in the array, those users will be authorized to access as well as any super users.
+   * Array of Username (HarperDB users) strings. Only used if `forceAuthorization` is `true`. If empty, the user used to authenticate must be a `super_user`. If there are any strings in the array, those users will be authorized to access as well as any super users.
+     3. `customMetrics`
+        * Object array of values that define converting Harper custom metric(s) to Prometheus metric(s). The definition is as follows:
+          * `metricAttribute` (required): The Harper metric name that needs to be processed as a custom Prometheus metric.
+          * `help` (required): The help text to be associated with the Prometheus metric.
+          * `labels` (required): Object array of label definitions for the Prometheus metric. The definition for labels:
+            * `label` (required): Name of the Prometheus label.
+            * `metricAttribute` (required): Name of the Harper label that maps to the Prometheus label.
+            * `delimiter` (optional): If the label value is a concatenated string, this defines the delimiter with which to split the data.
+            * `index` (optional / required with delimiter): This is used in conjunction with the delimiter attribute.  This creates the mapping from the split label value, based on delimiter, to the Prometheus label value.  `index` can also be used independently of delimiter if the Harper label value is an array.
+    
+          Example `customMetrics` value:      
+          ```json
+          {
+             "name": "customMetrics",
+              "value": [
+             {
+                "name": "myCoolMetric",
+                "metricAttribute": "metric",
+                "help": "this is the coolest metric",
+                "labels": [
+                  {
+                     "label": "coolLabel",
+                     "metricAttribute": "path"
+                     "delimiter": "::"
+                     "index": 0
+                  },
+                  {
+                     "label": "coolerLabel",
+                     "metricAttribute": "path"
+                     "delimiter": "::"
+                     "index": 1
+                  },
+                  {
+                     "label": "coolestLabel",
+                     "metricAttribute": "path"
+                     "delimiter": "::"
+                     "index": 2
+                  },
+                  {
+                     "label": "httpMethod",
+                     "metricAttribute": "method"
+                  },
+                  {
+                     "label": "statusCode",
+                     "metricAttribute": "type"
+                  }
+                ]
+            }
+          ]
+     }
+        ```
+
 
 ### Example REST commands
 ```bash
@@ -72,6 +124,50 @@ curl --location --request PUT 'http://localhost:9926/prometheus_exporter/Prometh
     "value": ["prometheus"]
 }'
 ```
+
+```bash
+curl --location --request PUT 'http://localhost:9926/prometheus_exporter/PrometheusExporterSettings/customMetrics' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Basic abcd' \
+--data '{
+   "name": "customMetrics",
+    "value": [
+   {
+      "name": "myCoolMetric",
+      "metricAttribute": "metric",
+      "help": "this is the coolest metric",
+      "labels": [
+        {
+           "label": "coolLabel",
+           "metricAttribute": "path"
+           "delimiter": "::"
+           "index": 0
+        },
+        {
+           "label": "coolerLabel",
+           "metricAttribute": "path"
+           "delimiter": "::"
+           "index": 1
+        },
+        {
+           "label": "coolestLabel",
+           "metricAttribute": "path"
+           "delimiter": "::"
+           "index": 2
+        },
+        {
+           "label": "httpMethod",
+           "metricAttribute": "method"
+        },
+        {
+           "label": "statusCode",
+           "metricAttribute": "type"
+        }
+      ]
+  }
+]'
+```
+
 ## Metrics
 We expose default metrics from the [Prometheus client](https://github.com/siimon/prom-client); a list of the metrics can be found [here](https://github.com/siimon/prom-client/blob/master/example/default-metrics.js).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harperdb/prometheus-exporter",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "HarperDB Prometheus Exporter",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Updated the Prometheus Exporter to include configurable custom metrics with detailed label definitions, enabling advanced metric conversion. Changes include enhancements to `resources.js` for label extraction logic and updates to documentation with examples for the new feature. Version bumped to 1.0.25 in `package.json`.