### PR TITLE
Fix custom metrics crashing the /metrics endpoint on Harper 5

### DIFF
--- a/resources.js
+++ b/resources.js
@@ -1020,16 +1020,14 @@ const recordProp = (record, key) =>
  */
 function outputCustomMetrics(customMetrics, metric, output) {
   customMetrics.forEach((custom_metric) => {
-    if (
-      metric[recordProp(custom_metric, "metricAttribute")] ===
-      recordProp(custom_metric, "name")
-    ) {
-      const customMetricName = recordProp(custom_metric, "name").replace(
-        /-/g,
-        "_",
-      );
+    const metricAttribute = recordProp(custom_metric, "metricAttribute");
+    const name = recordProp(custom_metric, "name");
+    // require both fields so a malformed entry can't match every metric
+    // via undefined === undefined and then crash on name.replace()
+    if (metricAttribute && name && metric[metricAttribute] === name) {
+      const customMetricName = name.replace(/-/g, "_");
       output.set(
-        `# HELP ${customMetricName} ${recordProp(custom_metric, "help")}`,
+        `# HELP ${customMetricName} ${recordProp(custom_metric, "help") ?? ""}`,
         null,
       );
       output.set(`# TYPE ${customMetricName} summary`, null);

--- a/resources.js
+++ b/resources.js
@@ -991,7 +991,7 @@ async function generateMetricsFromAnalytics(notFast) {
           break;
         }
         default:
-          if (notFast && customMetrics) {
+          if (notFast && Array.isArray(customMetrics)) {
             await outputCustomMetrics(customMetrics, metric, output);
           }
           break;
@@ -1004,6 +1004,12 @@ async function generateMetricsFromAnalytics(notFast) {
 // Call set() function on any gauge object with a default value of 0
 const gaugeSet = (gauge, options, value) => gauge?.set(options, value || 0);
 
+// Read a field from a custom-metric entry tolerantly: entries decode as
+// Map-like objects (.get()) on Harper 4 and plain (frozen) objects on
+// Harper 5 — support both
+const recordProp = (record, key) =>
+  typeof record?.get === "function" ? record.get(key) : record?.[key];
+
 /**
  * Processes custom metrics and appends formatted output to the provided output array.
  *
@@ -1015,11 +1021,15 @@ const gaugeSet = (gauge, options, value) => gauge?.set(options, value || 0);
 function outputCustomMetrics(customMetrics, metric, output) {
   customMetrics.forEach((custom_metric) => {
     if (
-      metric[custom_metric.get("metricAttribute")] === custom_metric.get("name")
+      metric[recordProp(custom_metric, "metricAttribute")] ===
+      recordProp(custom_metric, "name")
     ) {
-      const customMetricName = custom_metric.get("name").replace(/-/g, "_");
+      const customMetricName = recordProp(custom_metric, "name").replace(
+        /-/g,
+        "_",
+      );
       output.set(
-        `# HELP ${customMetricName} ${custom_metric.get("help")}`,
+        `# HELP ${customMetricName} ${recordProp(custom_metric, "help")}`,
         null,
       );
       output.set(`# TYPE ${customMetricName} summary`, null);
@@ -1076,7 +1086,7 @@ function outputCustomMetrics(customMetrics, metric, output) {
 function buildCustomLabels(customMetric, metric) {
   const labels = [];
 
-  customMetric.get("labels").forEach((label) => {
+  (recordProp(customMetric, "labels") ?? []).forEach((label) => {
     const labelValue = extractLabelValue(metric[label.metricAttribute], label);
     labels.push(`${label.label}="${labelValue}"`);
   });


### PR DESCRIPTION
## Summary

On Harper 5, custom-metric definitions stored in `PrometheusExporterSettings` (`customMetrics.value`) decode as plain frozen objects, but `outputCustomMetrics()` and `buildCustomLabels()` read their fields with Map-style `.get("field")` calls. The first configured custom metric throws:

```
TypeError: custom_metric.get is not a function
    at resources.js:1018 (outputCustomMetrics)
```

The exception propagates through `generateMetricsFromAnalytics` → `metrics.get`, so the **entire `/metrics` endpoint returns 500 on every scrape** — not just the custom metrics.

**Field evidence:** hit on a production 6-node 5.0.26 cluster with 5 custom metrics configured. All 6 nodes 500'd every scrape (~1/min each) since their v4→v5 upgrade; Datadog + Grafana Alloy collected nothing. Most installs never hit this because the default `customMetrics` is `[]` — the path is only exercised when custom metrics are actually configured.

## Changes

- Add `recordProp(record, key)` — reads a field via `.get()` when the entry is Map-like (Harper 4 decoding) and via plain property access otherwise (Harper 5). Used at the 5 former `.get()` call sites, so the component works on both major versions.
- Harden the two array assumptions in the same path: `Array.isArray(customMetrics)` at the call site and `?? []` around `labels`, so a malformed definition degrades to skipped output instead of 500ing the whole endpoint again.

## Where to look

- The dual-mode accessor vs. just switching to plain property access: kept dual-mode so 1.1.x remains installable on v4 clusters. If the package is v5-only going forward, the call sites can be simplified to `custom_metric[key]`.
- The `?? []` labels guard changes behavior for a malformed no-labels definition: previously a crash, now emits the metric with an empty label set (Prometheus' text format accepts the trailing comma). Skipping the metric entirely would also be defensible.

## Testing

No test infra in the repo. Verified by extracting `outputCustomMetrics`/`buildCustomLabels`/`recordProp` and exercising them with the real production custom-metric shapes as (a) Harper 5 plain objects, (b) Map entries, (c) a definition with no `labels`, and (d) a non-matching metric — all produce correct Prometheus output lines (12 entries per matching metric) with no throw. `node --check` and `prettier --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)