### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harperdb/prometheus-exporter",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Harper Prometheus Exporter",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
One-line release bump: `1.1.3` → `1.2.0` for the v5 custom-metrics compatibility fix (#46).

Tag `v1.2.0` points at this commit and is already pushed. **Please merge with a merge commit (not squash)** so the tagged commit stays reachable from main — if it gets squashed, the tag needs to be moved to the squash commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)